### PR TITLE
Extending tasks timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ safe_transaction_service/media
 
 # helm packages
 safe-transaction-service-*.tgz
+charts/safe-transaction/values-testing.yaml

--- a/safe_transaction_service/contracts/tasks.py
+++ b/safe_transaction_service/contracts/tasks.py
@@ -25,6 +25,8 @@ logger = get_task_logger(__name__)
 
 TASK_SOFT_TIME_LIMIT = 30  # 30 seconds
 TASK_TIME_LIMIT = 60  # 1 minute
+TASK_SOFT_TIME_LIMIT_EXTENDED = 60  # 1 minute
+TASK_TIME_LIMIT_EXTENDED = 120  # 2 minutes
 
 
 class ContractAction(Enum):
@@ -109,8 +111,8 @@ def reindex_contracts_without_metadata_task() -> int:
 
 
 @app.shared_task(
-    soft_time_limit=TASK_SOFT_TIME_LIMIT,
-    time_limit=TASK_TIME_LIMIT,
+    soft_time_limit=TASK_SOFT_TIME_LIMIT_EXTENDED,
+    time_limit=TASK_TIME_LIMIT_EXTENDED,
     autoretry_for=(EtherscanRateLimitError,),
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},

--- a/safe_transaction_service/contracts/tasks.py
+++ b/safe_transaction_service/contracts/tasks.py
@@ -23,10 +23,8 @@ from .models import Contract
 
 logger = get_task_logger(__name__)
 
-TASK_SOFT_TIME_LIMIT = 30  # 30 seconds
-TASK_TIME_LIMIT = 60  # 1 minute
-TASK_SOFT_TIME_LIMIT_EXTENDED = 60  # 1 minute
-TASK_TIME_LIMIT_EXTENDED = 120  # 2 minutes
+TASK_SOFT_TIME_LIMIT = 120  # 4 minutes
+TASK_TIME_LIMIT = 600  # 10 minute
 
 
 class ContractAction(Enum):
@@ -111,8 +109,8 @@ def reindex_contracts_without_metadata_task() -> int:
 
 
 @app.shared_task(
-    soft_time_limit=TASK_SOFT_TIME_LIMIT_EXTENDED,
-    time_limit=TASK_TIME_LIMIT_EXTENDED,
+    soft_time_limit=TASK_SOFT_TIME_LIMIT,
+    time_limit=TASK_TIME_LIMIT,
     autoretry_for=(EtherscanRateLimitError,),
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},


### PR DESCRIPTION
The default timeout for certain tasks is too low and makes the celery tasks to abort.