### PR TITLE
Use EthereumClientProvider in more places

### DIFF
--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -32,8 +32,6 @@ class Erc20EventsIndexerProvider:
 
     @classmethod
     def get_new_instance(cls) -> "Erc20EventsIndexer":
-        from django.conf import settings
-
         return Erc20EventsIndexer(EthereumClientProvider())
 
     @classmethod

--- a/safe_transaction_service/history/indexers/erc20_events_indexer.py
+++ b/safe_transaction_service/history/indexers/erc20_events_indexer.py
@@ -8,7 +8,7 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractEvent
 from web3.types import EventData, LogReceipt
 
-from gnosis.eth import EthereumClient
+from gnosis.eth import EthereumClientProvider
 
 from ...utils.utils import FixedSizeDict
 from ..models import (
@@ -34,7 +34,7 @@ class Erc20EventsIndexerProvider:
     def get_new_instance(cls) -> "Erc20EventsIndexer":
         from django.conf import settings
 
-        return Erc20EventsIndexer(EthereumClient(settings.ETHEREUM_NODE_URL))
+        return Erc20EventsIndexer(EthereumClientProvider())
 
     @classmethod
     def del_singleton(cls):

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -10,7 +10,7 @@ from hexbytes import HexBytes
 from web3.contract.contract import ContractEvent
 from web3.types import EventData
 
-from gnosis.eth import EthereumClient
+from gnosis.eth import EthereumClientProvider
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_V1_1_1_contract
 
@@ -43,7 +43,7 @@ class SafeEventsIndexerProvider:
     def get_new_instance(cls) -> "SafeEventsIndexer":
         from django.conf import settings
 
-        return SafeEventsIndexer(EthereumClient(settings.ETHEREUM_NODE_URL))
+        return SafeEventsIndexer(EthereumClientProvider())
 
     @classmethod
     def del_singleton(cls):

--- a/safe_transaction_service/history/indexers/safe_events_indexer.py
+++ b/safe_transaction_service/history/indexers/safe_events_indexer.py
@@ -41,8 +41,6 @@ class SafeEventsIndexerProvider:
 
     @classmethod
     def get_new_instance(cls) -> "SafeEventsIndexer":
-        from django.conf import settings
-
         return SafeEventsIndexer(EthereumClientProvider())
 
     @classmethod


### PR DESCRIPTION
This ensures the client uses some configuration values which can be modified through the env.